### PR TITLE
Deleted copy of testEquals method

### DIFF
--- a/src/testcases/RelationshipTest.java
+++ b/src/testcases/RelationshipTest.java
@@ -19,7 +19,6 @@ public class RelationshipTest {
 	}
 
 	@Test
-<<<<<<< HEAD
 	public void testEquals() {
 		Relationship r1 = new Relationship("A", "B", "C");
 		Relationship r2 = new Relationship("A", "B", "C");
@@ -45,32 +44,3 @@ public class RelationshipTest {
 	}
 
 }
-
-=======
-    public void testEquals()
-    {
-    	Relationship r1 = new Relationship("A","B","C");
-    	Relationship r2 = new Relationship("A","B","C");
-    	Relationship r3 = new Relationship("D","B","C");
-    	Relationship r4 = new Relationship("A","D","C");
-    	Relationship r5 = new Relationship("A","B","D");
-    	String s = "";
-    	
-    	// Null check
-    	assertFalse("Null should result in false", r1.equals(null));
-    	
-    	// Type check
-    	assertFalse("Differing object types should result in false", r1.equals(s));
-    	
-       	// Identity check
-    	assertTrue("Relationship should be equal with itself.", r1.equals(r1));
-    	
-    	// Equality check
-    	assertTrue("Relationships should be equal.", r1.equals(r2));
-    	assertFalse("Differing names should result in false", r1.equals(r3));
-    	assertFalse("Differing first classes should result in false", r1.equals(r4));
-    	assertFalse("Differing second classes should result in false", r1.equals(r5));
-    }
-
-}
-


### PR DESCRIPTION
There was a copy of the testEquals method that was left over from the latest merge with datastructures/tests. They are now deleted.