### PR TITLE
Fixes issues to multiple entities in GUI

### DIFF
--- a/src/main/java/mike/gui/Controller.java
+++ b/src/main/java/mike/gui/Controller.java
@@ -243,9 +243,7 @@ public class Controller extends guiHelperMethods {
 				String[] entityStrings = new String[entities.size()];
 				for(int x = 0; x < entities.size(); ++x) {
 					entityStrings[x] = entities.get(x).getName();
-				}
-				JComboBox<String> list = new JComboBox<>(entityStrings);
-				
+				}				
 				
 				/* React to the node selection. */
 				switch(node.toString()) {
@@ -255,14 +253,14 @@ public class Controller extends guiHelperMethods {
 					case "Create Relationship" : createRelation(classes,  entityStrings, frame); break;
 					case "Delete Relationship" : deleteRelation(classes, entityStrings, frame); break;
 					case "Create Field" : createFieldsOrMethods(classes, entityStrings, "Field", frame); break;
-					case "Rename Field" : renameFieldsOrMethods(classes, list, frame, "Field"); break;
-					case "Delete Field" : deleteFieldsOrMethods(classes, list, frame, "Field"); break;
+					case "Rename Field" : renameFieldsOrMethods(classes, frame, "Field"); break;
+					case "Delete Field" : deleteFieldsOrMethods(classes, frame, "Field"); break;
 					case "Create Method" : createFieldsOrMethods(classes, entityStrings, "Method", frame); break;
-					case "Rename Method" : renameFieldsOrMethods(classes, list, frame, "Method"); break;
-					case "Delete Method" : deleteFieldsOrMethods(classes, list, frame, "Method"); break;
-					case "Create Parameter" : createParameter(classes, list, frame); break;
-					case "Rename Parameter" : renameParameter(classes, list, frame); break;
-					case "Delete Parameter" : deleteParameter(classes, list, frame); break;
+					case "Rename Method" : renameFieldsOrMethods(classes, frame, "Method"); break;
+					case "Delete Method" : deleteFieldsOrMethods(classes, frame, "Method"); break;
+					case "Create Parameter" : createParameter(classes, frame); break;
+					case "Rename Parameter" : renameParameter(classes, frame); break;
+					case "Delete Parameter" : deleteParameter(classes, frame); break;
 					default : throw new RuntimeException("Unknown button pressed");
 				}
 				for(Entity curEntity : entities) {

--- a/src/main/java/mike/gui/GUI.java
+++ b/src/main/java/mike/gui/GUI.java
@@ -149,6 +149,7 @@ public class GUI implements ViewInterface {
 	}
 
 	public static void updateClass(String oldname, Entity e) {
+		System.out.println(oldname);
 		JLabel classObj = entityLabels.remove(oldname);
 		centerPanel.remove(classObj);
 		classObj.setText(entityToHTML(e));

--- a/src/main/java/mike/gui/GUI.java
+++ b/src/main/java/mike/gui/GUI.java
@@ -149,7 +149,6 @@ public class GUI implements ViewInterface {
 	}
 
 	public static void updateClass(String oldname, Entity e) {
-		System.out.println(oldname);
 		JLabel classObj = entityLabels.remove(oldname);
 		centerPanel.remove(classObj);
 		classObj.setText(entityToHTML(e));

--- a/src/main/java/mike/gui/guiHelperMethods.java
+++ b/src/main/java/mike/gui/guiHelperMethods.java
@@ -267,7 +267,7 @@ public class guiHelperMethods extends HelperMethods {
 
 	// Fields and methods were combined into one function due to striking similarity
 	//	in the underlying implementation.
-	public static void renameFieldsOrMethods(Classes classes, JComboBox<String> list, JFrame frame, String attribute) {
+	public static void renameFieldsOrMethods(Classes classes, JFrame frame, String attribute) {
 		
 		// Create a window asking for which class to choose from
 		JComboBox<String> finaleList = inputClass(classes.getEntities(), frame, attribute, false,
@@ -292,7 +292,7 @@ public class guiHelperMethods extends HelperMethods {
 
 		// Perform the proper renaming
 		if (result2 == 0) {
-			String entityname = list.getSelectedItem().toString();
+			String entityname = finaleList.getSelectedItem().toString();
 			if (attribute.equals("Field")) {
 				classes.renameField(entityname, List2.getSelectedItem().toString(), rename.getText());
 			} else {
@@ -305,7 +305,7 @@ public class guiHelperMethods extends HelperMethods {
 
 	// Fields and methods were combined into one function due to striking similarity
 	//	in the underlying implementation.
-	public static void deleteFieldsOrMethods(Classes classes, JComboBox<String> list, JFrame frame, String attribute) {
+	public static void deleteFieldsOrMethods(Classes classes, JFrame frame, String attribute) {
 		// Create a window asking for which class to choose from
 		JComboBox<String> finaleList = inputClass(classes.getEntities(), frame, attribute, false,
 				"Delete " + attribute);
@@ -326,7 +326,7 @@ public class guiHelperMethods extends HelperMethods {
 
 		// Perform the proper deletion
 		if (result2 == 0) {
-			String entityname = list.getSelectedItem().toString();
+			String entityname = finaleList.getSelectedItem().toString();
 			if (attribute.equals("Field")) {
 				classes.deleteField(entityname, List2.getSelectedItem().toString());
 			} else {
@@ -336,7 +336,7 @@ public class guiHelperMethods extends HelperMethods {
 		}
 	}
 
-	public static void createParameter(Classes classes, JComboBox<String> list, JFrame frame) {
+	public static void createParameter(Classes classes, JFrame frame) {
 		// Create a window asking for which class to choose from
 		JComboBox<String> finaleList = inputClass(classes.getEntities(), frame, "Method", false, "Create Parameter");
 		if (finaleList == null) {
@@ -359,14 +359,15 @@ public class guiHelperMethods extends HelperMethods {
 				JOptionPane.OK_CANCEL_OPTION);
 
 		if (result2 == 0) {
-			String entityname = list.getSelectedItem().toString();
+			String entityname = finaleList.getSelectedItem().toString();
+			System.out.println(entityname);
 			classes.createParameter(finaleList.getSelectedItem().toString(), methodList.getSelectedItem().toString(),
 					name.getText(), type.getText());
 			GUI.updateClass(entityname, classes.copyEntity(entityname));
 		}
 	}
 
-	public static void renameParameter(Classes classes, JComboBox<String> list, JFrame frame) {
+	public static void renameParameter(Classes classes, JFrame frame) {
 		// Create a window asking for which class to choose from
 		JComboBox<String> finaleList = inputClass(classes.getEntities(), frame, "Method", true, "Rename Parameter");
 		if (finaleList == null) {
@@ -419,14 +420,14 @@ public class guiHelperMethods extends HelperMethods {
 				JOptionPane.OK_CANCEL_OPTION);
 
 		if (result3 == 0) {
-			String entityname = list.getSelectedItem().toString();
+			String entityname = finaleList.getSelectedItem().toString();
 			classes.renameParameter(finaleList.getSelectedItem().toString(), methodList.getSelectedItem().toString(),
 					parameterList.getSelectedItem().toString(), name.getText());
 			GUI.updateClass(entityname, classes.copyEntity(entityname));
 		}
 	}
 
-	public static void deleteParameter(Classes classes, JComboBox<String> list, JFrame frame) {
+	public static void deleteParameter(Classes classes, JFrame frame) {
 		// Create a window asking for which class to choose from
 		JComboBox<String> finaleList = inputClass(classes.getEntities(), frame, "Method", true, "Delete Parameter");
 		if (finaleList == null) {
@@ -476,7 +477,7 @@ public class guiHelperMethods extends HelperMethods {
 				JOptionPane.OK_CANCEL_OPTION);
 
 		if (result3 == 0) {
-			String entityname = list.getSelectedItem().toString();
+			String entityname = finaleList.getSelectedItem().toString();
 			classes.deleteParameter(finaleList.getSelectedItem().toString(), methodList.getSelectedItem().toString(),
 					parameterList.getSelectedItem().toString());
 			GUI.updateClass(entityname, classes.copyEntity(entityname));
@@ -568,8 +569,13 @@ public class guiHelperMethods extends HelperMethods {
 		} else if (type == "Method" && opt == true) {
 			for (int x = 0; x < entities.size(); ++x) {
 				Entity re = entities.get(x);
-				if (re.getMethods().size() != 0 && re.getMethods().get(x).getParameters().size() != 0) {
-					finale.add(re);
+				if (re.getMethods().size() != 0) {
+					for(int y = 0; y < re.getMethods().size(); ++y) {
+						if(re.getMethods().get(y).getParameters().size() != 0) {
+							finale.add(re);
+						}
+					}
+					
 				}
 			}
 		}

--- a/src/main/java/mike/gui/guiHelperMethods.java
+++ b/src/main/java/mike/gui/guiHelperMethods.java
@@ -360,7 +360,6 @@ public class guiHelperMethods extends HelperMethods {
 
 		if (result2 == 0) {
 			String entityname = finaleList.getSelectedItem().toString();
-			System.out.println(entityname);
 			classes.createParameter(finaleList.getSelectedItem().toString(), methodList.getSelectedItem().toString(),
 					name.getText(), type.getText());
 			GUI.updateClass(entityname, classes.copyEntity(entityname));


### PR DESCRIPTION
## Proposed Changes
Fixes issues when renaming/deleting fields/methods/parameters to entities past the first one created.
  
## Types of Changes
- [X] Bugfix (Change to a current feature to improve functionality or prevent some issue)

## Further Comments
When renaming or deleting methods, fields, or parameters in an entity that was not the first one created in the GUI, the data structure would not receive the new information, AND the GUI itself would not update with the new information. This patch fixes both issues (they were part of the same error).
