### PR TITLE
Updates CLIView (#131)

### DIFF
--- a/src/main/java/mike/view/CLIView.java
+++ b/src/main/java/mike/view/CLIView.java
@@ -267,7 +267,7 @@ public class CLIView implements ViewInterface {
 		}
 	    } else if (commands[1].equals("parameter")) {
 		if (commands.length != 5) {
-		    System.out.println(errorMessage + commands[11] + "\n");
+		    System.out.println(errorMessage + commandUsage[11] + "\n");
 		    break;
 		}
 		if (classes.deleteParameter(commands[2], commands[3], commands[4])) {


### PR DESCRIPTION
Found a small bug when creating tests.  This changes commands[11] to commandUsage[11] on line 270.  When a user types in the wrong amount of arguments in "delete parameter", line 270 is printed, and we don't want to try print out the user's 12th argument!