### PR TITLE
Edit cli save

### DIFF
--- a/src/main/java/mike/cli/LoadCommand.java
+++ b/src/main/java/mike/cli/LoadCommand.java
@@ -12,57 +12,63 @@ import mike.view.CLIView;
 public class LoadCommand extends CommandObj {
 
     private static LineReader savePromptReader;
+    private File file;
 
-    public LoadCommand(Model m, CLIView v, String[] com, boolean p, LineReader reader) {
-	super(m, v, com, p);
-	savePromptReader = reader;
+    public LoadCommand(Model m, CLIView v, String[] com, boolean p, LineReader reader, File file) {
+        super(m, v, com, p);
+        savePromptReader = reader;
+        this.file = file;
     }
 
     public boolean execute() {
-	if (commands.length == 2) {
-	    try {
-		if (prompt) {
-		    System.out.println("\nYou have unsaved changes, are you sure you want to continue?");
-		    System.out.println("Type 'yes' to continue loading, or 'no' to go back.");
-		    prompt = savePrompt();
-		}
-		if (!prompt) {
-		    File file = new File(commands[1]);
-		    HelperMethods.load(file, model, null, null);
-		    return false;
-		}
-	    } catch (Exception e) {
-		view.printError("Failed to parse directory. Exiting.\n");
-		return prompt;
-	    }
-	} else {
-	    view.printError(errorMessage + commandUsage[1] + "\n");
-	    return prompt;
-	}
-	return prompt;
+        if (commands.length == 2) {
+            try {
+                if (prompt) {
+                    System.out.println("\nYou have unsaved changes, are you sure you want to continue?");
+                    System.out.println("Type 'yes' to continue loading, or 'no' to go back.");
+                    prompt = savePrompt();
+                }
+                if (!prompt) {
+                    file = new File(commands[1]);
+                    HelperMethods.load(file, model, null, null);
+                    return false;
+                }
+            } catch (Exception e) {
+                view.printError("Failed to parse directory. Exiting.\n");
+                return prompt;
+            }
+        } else {
+            view.printError(errorMessage + commandUsage[1] + "\n");
+            return prompt;
+        }
+        return prompt;
     }
 
     // Gets user input to set save prompt flag.
     // False if they wish to continue
     // True if they want to return
     private static boolean savePrompt() {
-	while (prompt) {
+        while (prompt) {
 
-	    String line = savePromptReader.readLine("", "", (MaskingCallback) null, null);
-	    line = line.trim();
+            String line = savePromptReader.readLine("", "", (MaskingCallback) null, null);
+            line = line.trim();
 
-	    if (line.equals("yes")) {
-		System.out.println("Proceeding.\n");
-		prompt = false;
-		break;
-	    } else if (line.equals("no")) {
-		System.out.println("Stopping.\n");
-		prompt = true;
-		break;
-	    }
-	    System.out.println("Invalid command. Type 'yes' to proceed, or 'no' to go back.");
-	}
-	return prompt;
+            if (line.equals("yes")) {
+                System.out.println("Proceeding.\n");
+                prompt = false;
+                break;
+            } else if (line.equals("no")) {
+                System.out.println("Stopping.\n");
+                prompt = true;
+                break;
+            }
+            System.out.println("Invalid command. Type 'yes' to proceed, or 'no' to go back.");
+        }
+        return prompt;
     }
+
+    public File getFile() {
+    	return file;
+	}
 
 }

--- a/src/main/java/mike/cli/SaveCommand.java
+++ b/src/main/java/mike/cli/SaveCommand.java
@@ -9,25 +9,46 @@ import mike.view.CLIView;
 
 public class SaveCommand extends CommandObj {
 
-    public SaveCommand(Model m, CLIView v, String[] com, boolean p) {
-	super(m, v, com, p);
+    private File file;
+
+    public SaveCommand(Model m, CLIView v, String[] com, boolean p, File file) {
+        super(m, v, com, p);
+        this.file = file;
     }
 
     public boolean execute() {
-	if (commands.length == 2) {
-	    try {
-		File file = new File(commands[1]);
-		HelperMethods.save(file, model);
-		System.out.println("File saved at: " + file.getAbsolutePath());
-	    } catch (IOException e) {
-		view.printError("Failed to parse directory. Exiting.");
-		return prompt;
-	    }
-	} else {
-	    view.printError(errorMessage + commandUsage[0] + "\n");
-	    return prompt;
-	}
-	return false;
+        if (commands.length == 2) {
+        	//save to new specified file path
+            try {
+                file = new File(commands[1]);
+                HelperMethods.save(file, model);
+                System.out.println("File saved at: " + file.getAbsolutePath());
+            } catch (IOException e) {
+                view.printError("Failed to parse directory. Exiting.");
+                return prompt;
+            }
+        } else if(commands.length == 1) {
+        	if(file == null) {
+        		System.out.println("Specify a file path to save to. Proper command usage is: " + commandUsage[0] + "\n");
+        		return prompt;
+			}
+        	//save to current file
+			try {
+				HelperMethods.save(file, model);
+				System.out.println("File saved at: " + file.getAbsolutePath());
+			} catch (IOException e) {
+				view.printError("Failed to parse directory. Exiting.");
+				return prompt;
+			}
+		} else {
+            view.printError(errorMessage + commandUsage[0] + "\n");
+            return prompt;
+        }
+        return false;
+    }
+
+    public File getFile() {
+        return file;
     }
 
 }

--- a/src/main/java/mike/cli/SaveCommand.java
+++ b/src/main/java/mike/cli/SaveCommand.java
@@ -29,7 +29,7 @@ public class SaveCommand extends CommandObj {
             }
         } else if(commands.length == 1) {
         	if(file == null) {
-        		System.out.println("Specify a file path to save to. Proper command usage is: " + commandUsage[0] + "\n");
+        		System.out.println("\nSpecify a file path to save to. Proper command usage is: " + commandUsage[0] + "\n");
         		return prompt;
 			}
         	//save to current file

--- a/src/main/java/mike/controller/CLIController.java
+++ b/src/main/java/mike/controller/CLIController.java
@@ -1,5 +1,6 @@
 package mike.controller;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 
@@ -39,175 +40,180 @@ public class CLIController extends ControllerType {
     private LineReader savePromptReader;
     private LineReader reader;
     private ArrayList<Memento> mementos;
+    private File file;
     protected int currMeme;
 
     public CLIController(Model model, ViewTemplate view) throws IOException {
-	super();
-	this.model = model;
-	this.view = (CLIView) view.getViewinterface();
-	currMeme = 0;
-	mementos = new ArrayList<Memento>();
-	mementos.add(new Memento(this.model));
+        super();
+        this.model = model;
+        this.view = (CLIView) view.getViewinterface();
+        currMeme = 0;
+        mementos = new ArrayList<Memento>();
+        mementos.add(new Memento(this.model));
 
-	terminal = TerminalBuilder.builder().system(true).build();
+        terminal = TerminalBuilder.builder().system(true).build();
 
-	AggregateCompleter completer = new TabCompleter().updateCompleter(model);
+        AggregateCompleter completer = new TabCompleter().updateCompleter(model);
 
-	StringsCompleter savePromptCompleter = new StringsCompleter("yes", "no");
+        StringsCompleter savePromptCompleter = new StringsCompleter("yes", "no");
 
-	history = new DefaultHistory();
+        history = new DefaultHistory();
 
-	parser = new DefaultParser();
-	parser.setEscapeChars(new char[] {});
+        parser = new DefaultParser();
+        parser.setEscapeChars(new char[]{});
 
-	reader = LineReaderBuilder.builder().terminal(terminal).completer(completer).history(history)
-		.variable(LineReader.MENU_COMPLETE, true).parser(parser).build();
+        reader = LineReaderBuilder.builder().terminal(terminal).completer(completer).history(history)
+                .variable(LineReader.MENU_COMPLETE, true).parser(parser).build();
 
-	savePromptReader = LineReaderBuilder.builder().terminal(terminal).completer(savePromptCompleter)
-		.variable(LineReader.MENU_COMPLETE, true).parser(parser).build();
+        savePromptReader = LineReaderBuilder.builder().terminal(terminal).completer(savePromptCompleter)
+                .variable(LineReader.MENU_COMPLETE, true).parser(parser).build();
     }
 
     public void init() {
-	view.printIntro();
+        view.printIntro();
 
-	while (true) {
-	    String line = null;
+        while (true) {
+            String line = null;
 
-	    line = reader.readLine("Enter a command: ", "", (MaskingCallback) null, null);
-	    line = line.trim();
+            line = reader.readLine("Enter a command: ", "", (MaskingCallback) null, null);
+            line = line.trim();
 
-	    String[] commands = line.split(" ");
+            String[] commands = line.split(" ");
 
-	    evaluateCommand(commands);
+            evaluateCommand(commands);
 
-	    // update completer
-	    AggregateCompleter completer = new TabCompleter().updateCompleter(model);
+            // update completer
+            AggregateCompleter completer = new TabCompleter().updateCompleter(model);
 
-	    // rebuild reader
-	    reader = LineReaderBuilder.builder().terminal(terminal).completer(completer).history(history)
-		    .variable(LineReader.MENU_COMPLETE, true).parser(parser).build();
-	}
+            // rebuild reader
+            reader = LineReaderBuilder.builder().terminal(terminal).completer(completer).history(history)
+                    .variable(LineReader.MENU_COMPLETE, true).parser(parser).build();
+        }
     }
 
     public void evaluateCommand(String[] commands) {
-	Memento meme = new Memento(new Model(this.model));
-	switch (commands[0]) {
-	case "quit":
-	    MiscCommand quit = new MiscCommand(model, view, commands, prompt, savePromptReader);
-	    prompt = quit.execute();
-	    break;
-	// Call help
-	case "help":
-	    MiscCommand help = new MiscCommand(model, view, commands, prompt, savePromptReader);
-	    prompt = help.execute();
-	    break;
-	// Call save depending on if pathname was specified or not
-	case "save":
-	    SaveCommand save = new SaveCommand(model, view, commands, prompt);
-	    prompt = save.execute();
-	    break;
-	// Call load given a directory+filename
-	case "load":
-	    LoadCommand load = new LoadCommand(meme.getModel(), view, commands, prompt, savePromptReader);
-	    prompt = load.execute();
-	    newMeme(meme);
-	    break;
-	// Call create class, field, method, or relationship based on length and user
-	// input
-	case "create":
-	    CreateCommand create = new CreateCommand(meme.getModel(), view, commands, prompt);
-	    prompt = create.execute();
-	    newMeme(meme);
-	    break;
-	// Call delete class, field, method, or relationship based on length and user
-	// input
-	case "delete":
-	    DeleteCommand delete = new DeleteCommand(meme.getModel(), view, commands, prompt);
-	    prompt = delete.execute();
-	    newMeme(meme);
-	    break;
-	// Call rename class, field, or method depending on user input and length
-	case "rename":
-	    RenameCommand rename = new RenameCommand(meme.getModel(), view, commands, prompt);
-	    prompt = rename.execute();
-	    newMeme(meme);
-	    break;
-	case "settype":
-	    SettypeCommand settype = new SettypeCommand(meme.getModel(), view, commands, prompt);
-	    prompt = settype.execute();
-	    newMeme(meme);
-	    break;
-	case "setvis":
-	    SetvisCommand setvis = new SetvisCommand(meme.getModel(), view, commands, prompt);
-	    prompt = setvis.execute();
-	    newMeme(meme);
-	    break;
-	// Call list class or relationship based on length and user input
-	case "list":
-	    ListCommand list = new ListCommand(model, view, commands, prompt);
-	    prompt = list.execute();
-	    break;
-	// Calls clear
-	case "clear":
-	    MiscCommand clear = new MiscCommand(meme.getModel(), view, commands, prompt, savePromptReader);
-	    prompt = clear.execute();
-	    newMeme(meme);
-	    break;
-	// Mostly for testing. Undocumented addition to allow for doing things without
-	// prompting.
-	case "sudo":
-	    MiscCommand sudo = new MiscCommand(model, view, commands, prompt, savePromptReader);
-	    prompt = sudo.execute();
-	    break;
-	// Proper command not detected, print an error
-	case "undo":
-	    undo();
-	    break;
-	case "redo":
-	    redo();
-	    break;
-	default:
-	    view.printInvalidCommand();
-	}
+        Memento meme = new Memento(new Model(this.model));
+        switch (commands[0]) {
+            case "quit":
+                MiscCommand quit = new MiscCommand(model, view, commands, prompt, savePromptReader);
+                prompt = quit.execute();
+                break;
+            // Call help
+            case "help":
+                MiscCommand help = new MiscCommand(model, view, commands, prompt, savePromptReader);
+                prompt = help.execute();
+                break;
+            // Call save depending on if pathname was specified or not
+            case "save":
+                SaveCommand save = new SaveCommand(model, view, commands, prompt, file);
+                prompt = save.execute();
+                //update file
+                file = save.getFile();
+                break;
+            // Call load given a directory+filename
+            case "load":
+                LoadCommand load = new LoadCommand(meme.getModel(), view, commands, prompt, savePromptReader, file);
+                prompt = load.execute();
+                //update file
+                file = load.getFile();
+                newMeme(meme);
+                break;
+            // Call create class, field, method, or relationship based on length and user
+            // input
+            case "create":
+                CreateCommand create = new CreateCommand(meme.getModel(), view, commands, prompt);
+                prompt = create.execute();
+                newMeme(meme);
+                break;
+            // Call delete class, field, method, or relationship based on length and user
+            // input
+            case "delete":
+                DeleteCommand delete = new DeleteCommand(meme.getModel(), view, commands, prompt);
+                prompt = delete.execute();
+                newMeme(meme);
+                break;
+            // Call rename class, field, or method depending on user input and length
+            case "rename":
+                RenameCommand rename = new RenameCommand(meme.getModel(), view, commands, prompt);
+                prompt = rename.execute();
+                newMeme(meme);
+                break;
+            case "settype":
+                SettypeCommand settype = new SettypeCommand(meme.getModel(), view, commands, prompt);
+                prompt = settype.execute();
+                newMeme(meme);
+                break;
+            case "setvis":
+                SetvisCommand setvis = new SetvisCommand(meme.getModel(), view, commands, prompt);
+                prompt = setvis.execute();
+                newMeme(meme);
+                break;
+            // Call list class or relationship based on length and user input
+            case "list":
+                ListCommand list = new ListCommand(model, view, commands, prompt);
+                prompt = list.execute();
+                break;
+            // Calls clear
+            case "clear":
+                MiscCommand clear = new MiscCommand(meme.getModel(), view, commands, prompt, savePromptReader);
+                prompt = clear.execute();
+                newMeme(meme);
+                break;
+            // Mostly for testing. Undocumented addition to allow for doing things without
+            // prompting.
+            case "sudo":
+                MiscCommand sudo = new MiscCommand(model, view, commands, prompt, savePromptReader);
+                prompt = sudo.execute();
+                break;
+            // Proper command not detected, print an error
+            case "undo":
+                undo();
+                break;
+            case "redo":
+                redo();
+                break;
+            default:
+                view.printInvalidCommand();
+        }
     }
 
     private void undo() {
-	if (currMeme > 0) {
-	    --currMeme;
-	    this.model = mementos.get(currMeme).getModel();
-	    prompt = true;
-	} else {
-	    System.out.println("No actions to undo.");
+        if (currMeme > 0) {
+            --currMeme;
+            this.model = mementos.get(currMeme).getModel();
+            prompt = true;
+        } else {
+            System.out.println("No actions to undo.");
 
-	}
+        }
     }
 
     private void redo() {
-	if (currMeme < mementos.size() - 1) {
-	    ++currMeme;
-	    this.model = mementos.get(currMeme).getModel();
-	    prompt = true;
-	} else {
-	    System.out.println("No actions to redo.");
-	}
+        if (currMeme < mementos.size() - 1) {
+            ++currMeme;
+            this.model = mementos.get(currMeme).getModel();
+            prompt = true;
+        } else {
+            System.out.println("No actions to redo.");
+        }
     }
 
     private void truncateMemes() {
-	if (currMeme < mementos.size() - 1) {
-	    for (int i = mementos.size() - 1; i > currMeme; --i) {
-		mementos.remove(i);
-	    }
-	}
+        if (currMeme < mementos.size() - 1) {
+            for (int i = mementos.size() - 1; i > currMeme; --i) {
+                mementos.remove(i);
+            }
+        }
     }
 
     private void newMeme(Memento meme) {
-	truncateMemes();
-	mementos.add(meme);
-	this.model = meme.getModel();
-	++currMeme;
+        truncateMemes();
+        mementos.add(meme);
+        this.model = meme.getModel();
+        ++currMeme;
     }
 
     public Model getModel() {
-	return model;
+        return model;
     }
 }

--- a/src/test/java/mike/cli/LoadCommandTest.java
+++ b/src/test/java/mike/cli/LoadCommandTest.java
@@ -3,7 +3,10 @@ package mike.cli;
 import mike.HelperMethods;
 import mike.controller.CLIController;
 import mike.datastructures.Model;
+import mike.view.CLIView;
 import mike.view.ViewTemplate;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
 import org.json.simple.parser.ParseException;
 import org.junit.After;
 import org.junit.Before;
@@ -21,6 +24,7 @@ public class LoadCommandTest {
     Model model;
     ViewTemplate view;
     CLIController control;
+    File file;
 
     private final ByteArrayOutputStream out = new ByteArrayOutputStream();
     private final ByteArrayOutputStream err = new ByteArrayOutputStream();
@@ -45,6 +49,7 @@ public class LoadCommandTest {
         System.setErr(origErr);
         String[] commands = {"sudo", "clear"};
         control.evaluateCommand(commands);
+        file = null;
     }
 
     private void resetStreams() {
@@ -76,7 +81,7 @@ public class LoadCommandTest {
         // Test relative Path
         String[] load = {"load", sep + "src" + sep + "test" + sep + "java" + sep + "mike" + sep + "testDemoCLI.json"};
         control.evaluateCommand(load);
-	File file = new File(System.getProperty("user.dir") + sep + "src" + sep + "test" + sep + "java" + sep + "mike" + sep + "testDemoCLI.json");
+	    file = new File(System.getProperty("user.dir") + sep + "src" + sep + "test" + sep + "java" + sep + "mike" + sep + "testDemoCLI.json");
         loadWorked(file);
 
         // Test absolute Path
@@ -86,13 +91,29 @@ public class LoadCommandTest {
         loadWorked(file2);
     }
 
-    private void loadWorked(File file) throws IOException, ParseException, java.text.ParseException {
-        HelperMethods.save(file, model);
+    private void loadWorked(File f) throws IOException, ParseException, java.text.ParseException {
+        HelperMethods.save(f, model);
         Model loadModel = new Model();
-        HelperMethods.load(file, loadModel, null, null);
+        HelperMethods.load(f, loadModel, null, null);
 
         assertEquals("loadModel contains a class.", 0, loadModel.getEntities().size());
         assertEquals("loadModel contains a relationship.", 0, loadModel.getRelationships().size());
+    }
+
+    @Test
+    public void testGetFile() {
+        CLIView cliView = new CLIView();
+        String[] com = { "commands", "array" };
+        LineReader reader = LineReaderBuilder.builder().build();
+        LoadCommand load = new LoadCommand(model, cliView, com, false, reader, file);
+
+        assertEquals("File passed in is not equal to LoadCommand's file", file, load.getFile());
+
+        //test with file not null
+        file = new File(System.getProperty("user.dir") + sep + "src" + sep + "test" + sep + "java" + sep + "mike" + sep + "testDemoCLI.json");
+        LoadCommand load2 = new LoadCommand(model, cliView, com, false, reader, file);
+
+        assertEquals("File passed in is not equal to LoadCommand's file", file, load2.getFile());
     }
 
 }

--- a/src/test/java/mike/cli/SaveCommandTest.java
+++ b/src/test/java/mike/cli/SaveCommandTest.java
@@ -58,11 +58,26 @@ public class SaveCommandTest {
 
     @Test
     public void saveTest() throws IOException, ParseException {
+        //Test only calling "save" with no current file
+        System.out.println("\nSpecify a file path to save to. Proper command usage is: \n  save <name>.json\n");
+        String expected = out.toString();
+        resetStreams();
+        String[] justSave = {"save"};
+        control.evaluateCommand(justSave);
+        assertEquals("save error message did not appear correctly.", expected, out.toString());
+        resetStreams();
+
+        //Test only calling "save" with a current file
+        file = new File(System.getProperty("user.dir") + partialPath + sep + "testDemoCLI.json");
+        control.evaluateCommand(justSave);
+        saveWorked(file);
+
+        resetStreams();
         // Test relative Path error length 4
         System.out.println("\nERROR: "
                 + "Error in parsing command. Proper command usage is: \n"
                 + "  save <name>.json\n");
-        String expected = out.toString();
+        expected = out.toString();
         resetStreams();
         String[] saveErr2 = {"save", "testDemoCLI.json", partialPath, "WRONG"};
         control.evaluateCommand(saveErr2);
@@ -72,7 +87,6 @@ public class SaveCommandTest {
         // Test relative Path
         String[] save = {"save", partialPath + sep + "testDemoCLI.json"};
         control.evaluateCommand(save);
-	File file = new File(System.getProperty("user.dir") + partialPath + sep + "testDemoCLI.json");
         saveWorked(file);
 
         // Test absolute Path
@@ -91,9 +105,9 @@ public class SaveCommandTest {
         saveWorked(file);
     }
 
-    private void saveWorked(File file) throws IOException, ParseException {
-        HelperMethods.save(file, model);
-        Object obj = new JSONParser().parse(new FileReader(file));
+    private void saveWorked(File f) throws IOException, ParseException {
+        HelperMethods.save(f, model);
+        Object obj = new JSONParser().parse(new FileReader(f));
 
         String emptyModelFile = "{\"Relationships\":[],\"Classes\":[]}";
         assertEquals("CLI is null; Should not be null.", emptyModelFile, obj.toString());

--- a/src/test/java/mike/cli/SaveCommandTest.java
+++ b/src/test/java/mike/cli/SaveCommandTest.java
@@ -3,7 +3,10 @@ package mike.cli;
 import mike.HelperMethods;
 import mike.controller.CLIController;
 import mike.datastructures.Model;
+import mike.view.CLIView;
 import mike.view.ViewTemplate;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.junit.After;
@@ -19,6 +22,7 @@ public class SaveCommandTest {
     Model model;
     ViewTemplate view;
     CLIController control;
+    File file;
     
     private final String sep = File.separator;
     private final String partialPath = sep + "src" + sep + "test" + sep + "java" + sep + "mike";
@@ -44,6 +48,7 @@ public class SaveCommandTest {
         System.setErr(origErr);
         String[] commands = {"sudo", "clear"};
         control.evaluateCommand(commands);
+        file = null;
     }
 
     private void resetStreams() {
@@ -92,6 +97,21 @@ public class SaveCommandTest {
 
         String emptyModelFile = "{\"Relationships\":[],\"Classes\":[]}";
         assertEquals("CLI is null; Should not be null.", emptyModelFile, obj.toString());
+    }
+
+    @Test
+    public void testGetFile() {
+        CLIView cliView = new CLIView();
+        String[] com = { "commands", "array" };
+        SaveCommand save = new SaveCommand(model, cliView, com, false, file);
+
+        assertEquals("File passed in is not equal to SaveCommand's file", file, save.getFile());
+
+        //test with file not null
+        file = new File(System.getProperty("user.dir") + sep + "src" + sep + "test" + sep + "java" + sep + "mike" + sep + "testDemoCLI.json");
+        SaveCommand save2 = new SaveCommand(model, cliView, com, false, file);
+
+        assertEquals("File passed in is not equal to SaveCommand's file", file, save2.getFile());
     }
 
 }

--- a/src/test/java/mike/cli/SaveCommandTest.java
+++ b/src/test/java/mike/cli/SaveCommandTest.java
@@ -72,6 +72,29 @@ public class SaveCommandTest {
         control.evaluateCommand(justSave);
         saveWorked(file);
 
+        //calling SaveCommand's execute to hit the try catch loop
+        //equivalent to executing the command "save" with a current working file
+        CLIView cliView = new CLIView();
+        SaveCommand saveCommand = new SaveCommand(model, cliView, justSave, false, file);
+
+        resetStreams();
+        System.out.println("File saved at: " + file.getAbsolutePath());
+        expected = out.toString();
+        resetStreams();
+        saveCommand.execute();
+        assertEquals("Save message did not appear correctly", expected, out.toString());
+        resetStreams();
+
+        //test with bad file (to hit the catch Exception)
+        saveCommand = new SaveCommand(model, cliView, justSave, false, new File("bad//dir./us.r/w"));
+        resetStreams();
+        System.out.println("\nERROR: Failed to parse directory. Exiting.");
+        expected = out.toString();
+        resetStreams();
+        saveCommand.execute();
+        assertEquals("Save error message did not appear correctly", expected, out.toString());
+        resetStreams();
+
         resetStreams();
         // Test relative Path error length 4
         System.out.println("\nERROR: "


### PR DESCRIPTION
## Proposed Changes
The CLIController now keeps track of a current file. Because of this, users can now simply type in "save" and it will save to the current working file. SaveCommand and LoadCommand also have a global File, which gets updated when calling execute, then CLIController calls their getFile functions to update its current file.
  
Example:
load uml.json (uml.json is now the current file)
save -> saves to uml.json

save uml2.json (uml2.json is now the current file)
save -> saves to uml2.json

If load or save with a specified file path was not called before, then save will not work because there is no current working file. Instead, it will print out an error message:

"Specify a file path to save to. Proper command usage is: 
save <name>.json" 
(Taken from the error message we already had before, just changed the text before it)


